### PR TITLE
Upgrade loofah Gem due to security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -440,7 +440,7 @@ GEM
     logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    loofah (2.2.0)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)


### PR DESCRIPTION
Versions of the loofah Gem < 2.2.1 are vulnerable to XSS (https://github.com/flavorjones/loofah/issues/144).  Thus, we upgrade to version 2.2.1.