### PR TITLE
Streamlined batch importing metadata file and data files

### DIFF
--- a/app/controllers/batch_imports_controller.rb
+++ b/app/controllers/batch_imports_controller.rb
@@ -1,0 +1,18 @@
+class BatchImportsController < ApplicationController
+
+  load_and_authorize_resource
+  
+  def create
+    @batch_import = BatchImport.new(params[:batch_import].merge(depositor: current_user.user_key))
+    if @batch_import.valid?
+      BatchImportJob.perform_later(manifest_file: @batch_import.manifest_file_full_path,
+                                   files_directory: @batch_import.files_directory_full_path,
+                                   depositor: @batch_import.depositor,
+                                   collection_id: @batch_import.collection_id)
+      render 'queued'
+    else
+      render 'new'
+    end
+  end
+
+end

--- a/app/jobs/batch_import_job.rb
+++ b/app/jobs/batch_import_job.rb
@@ -1,0 +1,13 @@
+class BatchImportJob < ApplicationJob
+
+  queue_as Hyrax.config.ingest_queue_name
+
+  def perform(args)
+    importer = Importer::CSVImporter.new(args[:manifest_file],
+                                         args[:files_directory],
+                                         args[:depositor],
+                                         args[:collection_id])
+    importer.import_all
+  end
+
+end

--- a/app/models/batch_import.rb
+++ b/app/models/batch_import.rb
@@ -1,0 +1,95 @@
+require 'importer'
+
+class BatchImport
+  include ActiveModel::Model
+
+  attr_accessor :files_directory, :manifest_file, :depositor
+
+  CONFIG_FILE = File.join(Rails.root, 'config', 'batch_import.yml')
+
+  validates_presence_of :manifest_file, :files_directory
+  validate :manifest_file_must_exist, if: Proc.new { manifest_file.present? }
+  validate :files_directory_must_exist, if: Proc.new { files_directory.present? }
+  validate :manifest_contents_must_be_valid, if: Proc.new { manifest_file_exists? && files_directory.present? }
+  validate :depositor_must_exist, if: Proc.new { depositor.present? }
+  validate :parent_collection_must_exist, if: Proc.new { files_directory.present? }
+
+  def self.basepath
+    if File.file?(CONFIG_FILE)
+      if (config = YAML.load(File.read(CONFIG_FILE))) && config.is_a?(Hash)
+        basepath = config.deep_symbolize_keys[:basepath]
+      end
+    end
+    basepath ||= File.join(Rails.root, 'tmp', 'imports')
+  end
+
+  def initialize(attributes = {})
+    attributes.each { |name, value| send("#{name}=", value) }
+  end
+
+  def persisted?
+    false
+  end
+
+  def parser
+    Importer::CSVParser.new(manifest_file_full_path)
+  end
+
+  def collection_id
+    collection, id = parent_collection
+    collection.id unless collection.nil?
+  end
+
+  def parent_collection
+    c_n = files_directory.split("/").first
+    collection_identifier = c_n[0...c_n.rindex('_')].gsub('_', '-') if c_n.include?('_')
+    return Collection.where(identifier: [collection_identifier]).first,  collection_identifier
+  end
+
+  def manifest_file_exists?
+    manifest_file.present? ? File.file?(manifest_file_full_path) : false
+  end
+ 
+  def manifest_file_full_path
+    File.join(self.class.basepath, manifest_file)
+  end
+
+  def files_directory_full_path
+    File.join(self.class.basepath, files_directory)
+  end
+
+  def manifest_file_must_exist
+    unless manifest_file_exists?
+      errors.add(:manifest_file, I18n.t('iawa.does_not_exist', target: manifest_file_full_path))
+    end
+  end
+
+  def files_directory_must_exist
+    unless Dir.exist?(files_directory_full_path)
+      errors.add(:files_directory, I18n.t('iawa.does_not_exist', target: files_directory_full_path))
+    end
+  end
+
+  def manifest_contents_must_be_valid
+    manifest = Importer::CSVManifest.new(manifest_file_full_path, files_directory_full_path)
+    unless manifest.valid?
+      manifest.errors.full_messages.each do |msg|
+        errors.add(:manifest_file, msg)
+      end
+    end
+  end
+
+   def depositor_must_exist
+    unless User.find_by_user_key(depositor).present?
+      errors.add(:depositor, "#{depositor} does not exist")
+    end
+  end
+
+  def parent_collection_must_exist
+    result, collection_identifier = parent_collection
+    if result.nil?
+      errors.add(:parent_collection, I18n.t('iawa.batch_import.parent_collection_does_not_exist', identifier: collection_identifier))
+    end
+  end
+     
+end

--- a/app/views/batch_imports/_files_directory.html.erb
+++ b/app/views/batch_imports/_files_directory.html.erb
@@ -1,0 +1,4 @@
+<div class="form-group">
+  <%= f.label :files_directory %>
+  <%= BatchImport.basepath %><%= f.text_field :files_directory, size: 50, class: "form_control" %>
+</div>

--- a/app/views/batch_imports/_manifest_file.html.erb
+++ b/app/views/batch_imports/_manifest_file.html.erb
@@ -1,0 +1,4 @@
+<div class="form-group">
+  <%= f.label :manifest_file %>
+  <%= BatchImport.basepath %><%= f.text_field :manifest_file, size: 50, class: "form_control" %>
+</div>

--- a/app/views/batch_imports/new.html.erb
+++ b/app/views/batch_imports/new.html.erb
@@ -1,0 +1,30 @@
+<h1><%= t('iawa.batch_import.heading') %></h1>
+<p>Please upload a CSV file to import items. The first row should be metadata fields, where the following fields are required:
+  <ul>
+  <li><b>Identifier</b>: single-value field</li>
+  <li><b>Title</b>: single-value field</li>
+  </ul>
+If the <b>Identifier</b> field matches an existing item, the item will be updated instead of creating a new one.
+</p>
+<%= form_for @batch_import do |f| %>
+  <% if @batch_import.errors.any? %>
+    <div id="error_explanation" class="col-md-12">
+      <h2><%= pluralize(@batch_import.errors.count, "error") %> prohibited this import from completing:</h2>
+      <ul>
+      <% @batch_import.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="row">
+    <div class="col-md-12">
+      <%= render partial: 'manifest_file', locals: {f: f} %>
+      <%= render partial: 'files_directory', locals: {f: f} %>
+      <div class="form-group">
+        <%= f.submit "Import", id: "batch_imports_submit_button", class: "btn btn-primary" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/batch_imports/queued.html.erb
+++ b/app/views/batch_imports/queued.html.erb
@@ -1,0 +1,23 @@
+<h1><%= t("rdr.batch_import.heading") %></h1>
+
+<p class="lead">
+  Batch Import Job queued.
+</p>
+
+<div class="row">
+  <div class="col-md-2">
+    <%= t('helpers.label.batch_import.manifest_file') %>:
+  </div>
+  <div class="col-md-4">
+    <%= @batch_import.manifest_file_full_path %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-2">
+    <%= t('helpers.label.batch_import.files_directory') %>:
+  </div>
+  <div class="col-md-4">
+    <%= @batch_import.files_directory_full_path %>
+  </div>
+</div>

--- a/app/views/hyrax/my/works/index.html.erb
+++ b/app/views/hyrax/my/works/index.html.erb
@@ -1,0 +1,87 @@
+<% provide :page_title, t("hyrax.admin.sidebar.works") %>
+
+<% provide :head do %>
+  <%= rss_feed_link_tag route_set: hyrax %>
+  <%= atom_feed_link_tag route_set: hyrax %>
+<% end %>
+
+<script>
+//<![CDATA[
+
+  <%= render partial: 'scripts', formats: [:js] %>
+
+//]]>
+</script>
+
+<% provide :page_header do %>
+  <h1><span class="fa fa-file"></span> <%= t("hyrax.admin.sidebar.works") %></h1>
+  <% if current_ability.can_create_any_work? %>
+    <div class="pull-right">
+      <% if @create_work_presenter.many? %>
+        <% if Flipflop.batch_upload? %>
+          <%= link_to(
+                t(:'helpers.action.batch.new'),
+                '#',
+                data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'batch' },
+                class: 'btn btn-primary'
+              ) %>
+        <% end %>
+        <%= link_to(
+              t(:'helpers.action.work.new'),
+              '#',
+              data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'single' },
+              class: 'btn btn-primary'
+            ) %>
+      <% else # simple link to the first work type %>
+        <%# added batch import by IAWA -%>
+        <% if current_ability.can? :create, BatchImport %>
+          <%= link_to(
+              t('iawa.batch_import.heading'),
+              [main_app, :new_batch_import],
+              class: 'btn btn-primary'
+              ) %>
+        <% end %>
+        <% if Flipflop.batch_upload? %>
+          <%= link_to(
+              t(:'helpers.action.batch.new'),
+              hyrax.new_batch_upload_path(payload_concern: @create_work_presenter.first_model),
+              class: 'btn btn-primary'
+              ) %>
+        <% end %>
+        <%= link_to(
+              t(:'helpers.action.work.new'),
+              new_polymorphic_path([main_app, @create_work_presenter.first_model]),
+              class: 'btn btn-primary'
+            ) %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default <%= 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>">
+      <%= render 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>
+      <div class="panel-heading">
+        <% if current_page?(hyrax.my_works_path(locale: nil)) %>
+          <span class="count-display"><%= I18n.t('hyrax.my.count.works.you_own', total_count: @response.total_count).html_safe %></span>
+        <% elsif current_page?(hyrax.dashboard_works_path(locale: nil)) && !current_ability.admin? %>
+          <span class="count-display"><%= I18n.t('hyrax.my.count.works.you_manage', total_count: @response.total_count).html_safe %></span>
+        <% else %>
+          <span class="count-display"><%= I18n.t('hyrax.my.count.works.in_repo', total_count: @response.total_count).html_safe %></span>     
+        <% end %>
+      </div> 
+      <div class="panel-body">
+        <%= render 'search_header' %>
+        <h2 class="sr-only">Works listing</h2>
+        <%= render 'document_list' %>
+
+        <%= render 'results_pagination' %>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+<%= render '/shared/select_work_type_modal', create_work_presenter: @create_work_presenter if @create_work_presenter.many? %>

--- a/app/views/shared/_citations.html.erb
+++ b/app/views/shared/_citations.html.erb
@@ -1,0 +1,33 @@
+<% content_for(:twitter_meta) do %>
+  <meta name="twitter:card" content="product" />
+  <meta name="twitter:site" content="<%= t('hyrax.product_twitter_handle') %>" />
+  <meta name="twitter:creator" content="<%= @presenter.tweeter %>" />
+  <meta property="og:site_name" content="<%= application_name %>" />
+  <meta property="og:type" content="object" />
+  <meta property="og:title" content="<%= @presenter.title.first %>" />
+  <meta property="og:description" content="<%= @presenter.description.first.truncate(200) rescue @presenter.title.first %>" />
+  <meta property="og:image" content="<%= @presenter.download_url %>" />
+  <meta property="og:url" content="<%= polymorphic_url([main_app, @presenter]) %>" />
+  <meta name="twitter:data1" content="<%= @presenter.keyword.join(', ') %>" />
+  <meta name="twitter:label1" content="Keywords" />
+  <meta name="twitter:data2" content="<%= @presenter.rights_statement.first %>" />
+  <meta name="twitter:label2" content="Rights Statement" />
+<% end %>
+
+<% content_for(:gscholar_meta) do %>
+  <meta name="citation_title" content="<%= @presenter.title.first %>" />
+  <% @presenter.creator.each do |creator| %>
+  <meta name="citation_author" content="<%= creator %>" />
+  <% end %>
+  <%# IAWA customization -%> 
+  <meta name="citation_publication_date" content="<%= @presenter.date_created %>" />
+  <meta name="citation_pdf_url" content="<%= @presenter.download_url %>" />
+  <!-- Hyrax does not yet support these metadata -->
+  <!--
+    <meta name="citation_journal_title" content=""/>
+    <meta name="citation_volume" content=""/>
+    <meta name="citation_issue" content=""/>
+    <meta name="citation_firstpage" content=""/>
+    <meta name="citation_lastpage" content=""/>
+  -->
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,7 @@ module Hyrax2
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+     config.autoload_paths += %W(#{config.root}/lib)
     # Overrides
     config.to_prepare do
       Hyrax::Forms::CollectionForm.prepend Hyrax::Forms::CollectionFormOverride

--- a/config/batch_import.yml
+++ b/config/batch_import.yml
@@ -1,0 +1,1 @@
+basepath: /var/local/hydra/hyrax2/tmp/imports

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -271,7 +271,7 @@ Hyrax.config do |config|
   # ingest files from the file system that are not part of the BrowseEverything
   # mount point.
   #
-  # config.whitelisted_ingest_dirs = []
+  config.whitelisted_ingest_dirs = [ File.join(Rails.root, 'tmp', 'imports') ] 
 end
 
 Date::DATE_FORMATS[:standard] = "%m/%d/%Y"

--- a/config/initializers/hyrax2.rb
+++ b/config/initializers/hyrax2.rb
@@ -1,0 +1,3 @@
+# Separator used in batch import manifest CSV file to separate multi-valued field
+# in a single CSV cell
+Hyrax2::Application.config.csv_mv_separator = "~"

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -116,16 +116,12 @@ en:
         header: Save Item
     batch_uploads:
       new:
-        header: Batch Attach Files to Items
+        header: Batch Create New Items
         in_collections: These Items in Collections
       progress:
         header: Save Items
       files:
         instructions: Each file will be attach to the corresponding item based on the naming convention.
-    batch_import:
-      new:
-        header: Batch Import Items
-        after_import_html: "Your metadata are being imported by %{application_name} in the background. Items will be marked <span class=\"label label-danger\" title=\"Private\">Private</span> until this process is complete (shouldn't take too long, hang in there!). You may need to refresh this page to see these updates." 
     collection:
       actions:
         add_works:

--- a/config/locales/iawa.en.yml
+++ b/config/locales/iawa.en.yml
@@ -1,0 +1,9 @@
+en:
+  iawa:
+    does_not_exist: "%{target} does not exist"
+    batch_import:
+      heading: "Batch Import Items"
+      invalid_metadata_header: "Invalid header: %{header}"
+      invalid_metadata_value: "Invalid value in row %{row}: %{value} for metadata %{field}"
+      unknow_file_type: "Unknown file type: %{file}"
+      parent_collection_does_not_exist: "does not exist with identifier %{identifier}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   
   resources :controlled_vocabs
+  resources :batch_imports, only: [:new, :create], controller: 'batch_imports'
   mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
   mount Blacklight::Engine => '/'
   

--- a/lib/importer.rb
+++ b/lib/importer.rb
@@ -1,0 +1,6 @@
+module Importer
+  extend ActiveSupport::Autoload
+  autoload :CSVImporter
+  autoload :CSVManifest
+  autoload :CSVParser
+end

--- a/lib/importer/csv_importer.rb
+++ b/lib/importer/csv_importer.rb
@@ -1,0 +1,52 @@
+module Importer
+  # Import a csv file with one work per row. The first row of the csv should be a
+  # header row.
+  class CSVImporter
+
+    attr_reader :manifest_file, :files_directory, :depositor, :collection_id
+
+    def initialize(manifest_file, files_directory, depositor, collection_id)
+      @manifest_file = manifest_file
+      @files_directory = files_directory
+      @depositor = depositor
+      @collection_id = collection_id
+    end
+
+    # @return [Integer] count of objects created
+    def import_all
+      count = 0
+      files_dir_array = Dir.glob(files_directory + "/**/Access")
+      parser.each do |attributes|
+        attrs = attributes.merge(deposit_attributes).merge(visibility_attributes)
+        obj_id = attrs[:identifier].first
+        obj_file_dir = files_dir_array.detect { |f_d| f_d.end_with?(obj_id + "/Access") }
+        create_fedora_objects(attrs, obj_file_dir, collection_id)
+        count += 1
+      end
+      count
+    end
+
+    private
+
+    def deposit_attributes
+      { depositor: depositor }
+    end
+
+    def visibility_attributes
+      { visibility: "open" }
+    end
+
+    def parser
+      CSVParser.new(manifest_file)
+    end
+
+    # Build a factory to create the objects in fedora.
+    # @param [Hash<Symbol => String>] attributes
+    def create_fedora_objects(attributes, files_directory, collection_id)
+      factory_class = Factory.for("Item")
+      f = factory_class.new(attributes, files_directory, collection_id)
+      f.run
+    end
+
+  end
+end

--- a/lib/importer/csv_manifest.rb
+++ b/lib/importer/csv_manifest.rb
@@ -1,0 +1,77 @@
+module Importer
+  class CSVManifest
+    include ActiveModel::Validations
+
+    attr_reader :files_directory, :manifest_file
+    validate :manifest_file_type
+    validate :metadata_headers
+    validate :controlled_vocab_values
+
+    def self.controlled_vocab_fields
+      ["medium", "resource_type", "keyword"]
+    end
+
+    def self.controlled_vocab_headers
+      @controlled_vocab_headers ||= controlled_vocab_fields.map(&:to_sym)
+    end
+
+    def self.controlled_vocab_hash
+      @controlled_vocab_hash =
+        controlled_vocab_fields.inject({}) do |hash, vocab|
+          hash.update(vocab => ControlledVocab.where(field: vocab + "_sim").all.map { |entry| entry.name } )
+        end
+    end
+
+    def self.controlled_vocab_names(vocab_field)
+      controlled_vocab_hash[vocab_field]
+    end
+
+    def self.valid_headers
+      ["Identifier", "Collection Identifier", "Title", "Circa", "Start Date", "End Date", 
+       "Description", "Subject", "Type", "Medium", "Format", "Creator", "Source", "Is Part Of",
+       "Language", "Coverage", "Tags", "Related URL", "Contributor", "file"]  
+    end
+
+    def initialize(manifest_file, files_directory)
+      @manifest_file = manifest_file
+      @files_directory = files_directory
+    end
+
+    def parser
+      @parser ||= CSVParser.new(manifest_file)
+    end
+
+    def manifest_file_type
+      unless File.extname(manifest_file) == ".csv"
+        errors.add(:file, I18n.t('iawa.batch_import.unknow_file_type', file: manifest_file))
+      end
+    end
+
+    def metadata_headers
+      parser.headers.each do |header|
+        unless self.class.valid_headers.include?(header)
+          errors.add(:base, I18n.t('iawa.batch_import.invalid_metadata_header', header: header))
+        end
+      end
+    end
+
+    def controlled_vocab_values
+      parser.each_with_index do |attributes, idx|
+        attributes.each do |field, values|
+          if self.class.controlled_vocab_headers.include?(field)
+            values.each do |value|
+              validate_attribute_value(field, value, idx)
+            end
+          end
+        end
+      end
+    end
+
+    def validate_attribute_value(field, value, idx)
+      unless self.class.controlled_vocab_names(field.to_s).include?(value)
+        errors.add(field, I18n.t('iawa.batch_import.invalid_metadata_value', row: "#{idx+2}", field: field, value: value))
+      end
+    end
+
+  end
+end

--- a/lib/importer/csv_parser.rb
+++ b/lib/importer/csv_parser.rb
@@ -1,0 +1,72 @@
+module Importer
+  class CSVParser
+    include Enumerable
+
+    attr_reader :file_name
+
+    def initialize(file_name)
+      @file_name = file_name
+    end
+
+    def headers
+      @headers = as_csv_table.headers.compact
+    end
+
+    def each(&_block)
+      as_csv_table.each do |row|
+        yield attributes(row)
+      end
+    end
+
+    private
+
+    # for each row
+    def attributes(row)
+      {}.tap do |parsedHash|
+        row.each do |header, val|
+          extract_field(header, val, parsedHash)
+        end
+      end
+    end
+
+    def extract_field(header, val, parsedHash)
+      unless val.blank?
+        case header
+        when 'Collection Identifier'
+          parsedHash[:collection_id] = val
+        when 'Circa'
+          if val == 'Yes'
+            parsedHash[:date_created] = "Circa "  
+          end
+        when 'Start Date'
+          parsedHash[:date_created] ||= ""
+          parsedHash[:date_created] += val 
+        when 'End Date'
+          parsedHash[:date] = val
+        when 'Type'
+          extract_multi_value_field(header, val, parsedHash, key = 'resource_type')
+        when 'Tags'
+          extract_multi_value_field(header, val, parsedHash, key = 'keyword')
+        when 'Is Part Of'
+          extract_multi_value_field(header, val, parsedHash, key = 'location')
+        when 'Related URL'
+          extract_multi_value_field(header, val, parsedHash, key = 'related_url')
+        else
+          extract_multi_value_field(header, val, parsedHash)
+        end
+      end
+    end
+
+    def extract_multi_value_field(header, val, parsedHash, key = nil)
+      key ||= header.downcase
+      key = key.to_sym
+      parsedHash[key] ||= []
+      separator = Rails.configuration.csv_mv_separator
+      parsedHash[key] += val.split(separator).map(&:strip)
+    end
+
+    def as_csv_table
+      @csv_table ||= CSV.read(file_name, headers: true)
+    end
+  end
+end

--- a/lib/importer/factory.rb
+++ b/lib/importer/factory.rb
@@ -1,0 +1,17 @@
+module Importer
+  module Factory
+    extend ActiveSupport::Autoload
+
+    eager_autoload do
+      autoload :CollectionFactory
+      autoload :ItemFactory
+      autoload :ObjectFactory
+      autoload :WithAssociatedCollection
+    end
+
+    # @param [#to_s] First (Xxx) portion of an "XxxFactory" constant
+    def self.for(model_name)
+      const_get "#{model_name}Factory"
+    end
+  end
+end

--- a/lib/importer/factory/collection_factory.rb
+++ b/lib/importer/factory/collection_factory.rb
@@ -1,0 +1,22 @@
+module Importer
+  module Factory
+    class CollectionFactory < ObjectFactory
+      self.klass = Collection
+
+      def find_or_create
+        collection = find
+        return collection if collection
+        run(&:save!)
+      end
+
+      def update
+        raise "Collection doesn't exist" unless object
+        object.attributes = update_attributes
+        run_callbacks(:save) do
+          object.save!
+        end
+        log_updated(object)
+      end
+    end
+  end
+end

--- a/lib/importer/factory/item_factory.rb
+++ b/lib/importer/factory/item_factory.rb
@@ -1,0 +1,10 @@
+module Importer
+  module Factory
+    class ItemFactory < ObjectFactory
+      include WithAssociatedCollection
+
+      self.klass = Item
+
+    end
+  end
+end

--- a/lib/importer/factory/object_factory.rb
+++ b/lib/importer/factory/object_factory.rb
@@ -1,0 +1,157 @@
+require 'importer/log_subscriber'
+
+module Importer
+  module Factory
+    class ObjectFactory
+      extend ActiveModel::Callbacks
+      define_model_callbacks :save, :create
+      class_attribute :klass
+      attr_reader :attributes, :collection_ids, :files_directory, :object
+
+      def initialize(attributes, files_dir = nil, collection_id)
+        @attributes = attributes
+        @files_directory = files_dir
+        @collection_ids = Array(collection_id)
+      end
+
+      def run
+        arg_hash = { id: attributes[:identifier].first, name: 'UPDATE', klass: klass }
+        @object = find
+        if @object
+          ActiveSupport::Notifications.instrument('import.importer', arg_hash) { update }
+        else
+          ActiveSupport::Notifications.instrument('import.importer', arg_hash.merge(name: 'CREATE')) { create }
+        end
+        yield(object) if block_given?
+        object
+      end
+
+      def update
+        raise "Object doesn't exist" unless object
+        run_callbacks(:save) do
+          work_actor.update(environment(update_attributes))
+        end
+        log_updated(object)
+      end
+
+      def create
+        attrs = create_attributes
+        @object = klass.new
+        run_callbacks :save do
+          run_callbacks :create do
+            klass == Collection ? create_collection(attrs) : work_actor.create(environment(attrs))           
+          end
+        end
+        log_created(object)
+      end
+
+      def create_attributes
+        transform_attributes
+      end
+
+      def update_attributes
+        transform_attributes.except(:identifier)
+      end
+
+      def find
+        if identifier = attributes[:identifier].first
+          return find_by_identifier(identifier)
+        end
+      end
+
+      def log_created(obj)
+        msg = "Created #{klass.model_name.human} #{obj.id}"
+        Rails.logger.info(msg)
+      end
+
+      def log_updated(obj)
+        msg = "Updated #{klass.model_name.human} #{obj.id}"
+        Rails.logger.info(msg)
+      end
+
+      def find_by_identifier(identifier)
+        identifier_field_name = ActiveFedora.index_field_mapper.solr_name('identifier', :stored_sortable)
+        results = klass.where(identifier_field_name => identifier)
+        if results.count > 1
+          raise Iawa::UnexpectedMultipleResultsError, I18n.t('iawa.unexpected_multiple_results', identifier: identifier)
+        else
+          results.first
+        end
+      end
+
+      def parent_ids
+        if parent = find_by_identifier(parent_identifier)
+          parent.id
+        end
+      end
+
+      private
+
+      # Override if we need to map the attributes from the parser in
+      # a way that is compatible with how the factory needs them.
+      def transform_attributes
+        sanitized_attributes
+            .merge(file_attributes)
+            .merge(collection_membership_attributes)
+      end
+
+      def sanitized_attributes
+        permitted_attributes.each_with_object({}) do |(k, v), memo|
+          if klass.delegated_attributes.key?(k)
+            value = Array(v)
+            memo[k] = klass.multiple?(k) ? value : value.first
+          else
+            memo[k] = v
+          end
+        end
+      end
+
+      def permitted_attributes
+        attributes.slice(*permitted_attribute_names)
+      end
+
+      def permitted_attribute_names
+        klass.properties.keys.map(&:to_sym) +
+            [ :admin_set_id, :parent_identifiers, :edit_users, :edit_groups, :read_groups, :visibility ]
+      end
+
+      def collection_membership_attributes
+        collection_ids.present? ? { member_of_collection_ids: collection_ids } : {}
+      end
+
+      def file_attributes
+        files_directory.present? ? { remote_files: remote_files } : {}
+      end
+
+      def nesting_attributes
+        parent_identifiers.present? ? { in_works_ids: parent_identifiers.map { |identifier| parent_id(identifier) } } : {}
+      end
+
+      def visibility_attributes
+        visibility.present? ? { visibility: visibility.first } : {}
+      end
+
+      def import_user(attrs)
+        attrs[:depositor].present? ? User.find_by_user_key(attrs[:depositor]) : User.batch_user
+      end
+
+      def remote_files
+        Dir.glob(files_directory + "/*.tif").map do |f|
+          Rails.logger.info("Files directory #{f}")
+          { url: "file:#{f}", file_name: File.basename(f) }
+        end
+      end
+
+      # @param [Hash] attrs the attributes to put in the environment
+      # @return [Hyrax::Actors::Environment]
+      def environment(attrs)
+        Hyrax::Actors::Environment.new(@object, Ability.new(import_user(attrs)), attrs)
+      end
+
+      def work_actor
+        Hyrax::CurationConcern.actor
+      end
+
+    end
+  end
+end

--- a/lib/importer/factory/with_associated_collection.rb
+++ b/lib/importer/factory/with_associated_collection.rb
@@ -1,0 +1,20 @@
+module Importer
+  module Factory
+    module WithAssociatedCollection
+      extend ActiveSupport::Concern
+
+      # Strip out the :collection key, and add the member_of_collection_ids,
+      # which is used by Hyrax::Actors::AddAsMemberOfCollectionsActor
+      def create_attributes
+        return super if attributes[:collection].nil?
+        super.except(:collection).merge(member_of_collection_ids: [collection.id])
+      end
+
+      private
+
+      def collection
+        CollectionFactory.new(attributes.fetch(:collection)).find_or_create
+      end
+    end
+  end
+end

--- a/lib/importer/log_subscriber.rb
+++ b/lib/importer/log_subscriber.rb
@@ -1,0 +1,39 @@
+module Importer
+  class LogSubscriber < ActiveSupport::LogSubscriber
+    def initialize
+      super
+      @odd = false
+    end
+
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def import(event)
+      return unless logger.debug?
+
+      payload = event.payload
+
+      name  = "#{payload[:name]} (#{event.duration.round(1)}ms)"
+      id    = payload[:id] || '[no id]'
+      klass = payload[:klass]
+
+      if odd?
+        name = color(name, CYAN, true)
+        id = color(id, nil, true)
+      else
+        name = color(name, MAGENTA, true)
+      end
+
+      debug "  #{name} #{klass} #{id}"
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+    def odd?
+      @odd = !@odd
+    end
+
+    def logger
+      ActiveFedora::Base.logger
+    end
+  end
+end
+
+Importer::LogSubscriber.attach_to :importer

--- a/lib/tasks/vt_hyrax2.rake
+++ b/lib/tasks/vt_hyrax2.rake
@@ -73,36 +73,41 @@ namespace :vt_hyrax2 do
   desc 'Establish initial controlled vocabularies for medium, tags, resource type fields'
   task add_controlled_vocabs: :environment do
     medium_names = ["Blueprints", "Charcoal", "Color pencil", "Computer-aided design",
-		    "Graphite", "Ink","Marker pen", "Linocuts (prints)",
+		    "Diazotypes (copies)", "Graphite", "Ink", "Linocuts (prints)",
+                    "Marker pen", "Negatives (photographs)", "Pastels (Visual works)",
                     "Photographic Print - Black and White", "Photographic print - Color",
-		    "Printed ink", "Watercolors", "Woodcut (prints)"]
+		    "Printed ink", "Slides (photographs)", "Stats (copies)", "Watercolors",
+                    "Woodcut (prints)"]
     medium_names.each do |name|
       ControlledVocab.find_or_create_by(name: name) do |c_v|
         c_v.field = 'medium_sim'
         c_v.image_filename = name.downcase.gsub(/[\W_]/,'') + '.jpg'
       end
     end
-    type_names = ["Articles", "Clippings", "Correspondence", "Curriculum Vitae",
-                  "Digital 3D model", "Computer drawings", "Digital renderings",
-                  "Documents", "Architectural drawings (visual works)", "As-built drawings",
-                  "Axonometric projections (images)", "Conceptual drawings",
-                  "Detail drawings (drawings)", "Detail studies", "Elevations (orthographic projections)",
-                  "Floor plans (orthographic projections)", "Interior design",
-                  "Perspective views (images)", "Presentation drawings (proposals)",
-                  "Sections (orthographic projections)", "Site plans", "Letters",
-                  "Newsletters", "Notebooks", "Pamphlets", "Photographs", "Architectural models",
-                  "Postcards", "Posters", "Scale models", "Sketchbooks", "Sketches", "Travel sketches"]
+    type_names = ["Architectural drawings (visual works)", "Architectural models", "Articles",
+                  "As-built drawings", "Axonometric projections (images)", "Clippings",
+                  "Computer drawings", "Conceptual drawings", "Contact sheets", "Correspondence",
+                  "Curriculum Vitae", "Detail drawings (drawings)", "Detail studies",
+                  "Digital 3D model", "Digital renderings", "Documents", "Elevations (orthographic projections)",
+                  "Ephemera", "Floor plans (orthographic projections)", "Handbooks and manuals",
+                  "Interior design", "Letters", "Maps", "Newsletters", "Notebooks", "Pamphlets",
+                  "Perspective views (images)", "Photographs", "Postcards", "Posters",
+                  "Presentation drawings (proposals)", "Scale models", "Schedules (architectural records)",
+                  "Sections (orthographic projections)", "Site plans", "Sketchbooks", "Sketches", "Travel sketches"]
     type_names.each do |name|
       ControlledVocab.find_or_create_by(name: name) do |c_v|
         c_v.field = 'resource_type_sim'
         c_v.image_filename = name.downcase.gsub(/[\W_]/,'') + '.jpg'
       end
     end
-    keyword_names = ["single-story", "two-story", "3 to 5 stories", "6 to 10 stories", "11 to 20 stories",
-                  "Commercial and Office", "Educational and Research", "Healthcare", "Industrial",
-                  "Interior Design", "Landscape Architecture", "Portrait", "Residential",
-                  "Residential-Housing development", "Residential-Multi-family", "Residential-Single-family",
-                  "Single-family", "Urban Design", "Student projects"]
+    keyword_names = ["11 to 20 stories", "3 to 5 stories", "6 to 10 stories", "Associations and committees",
+                     "Awards", "Biographical information", "Commercial and Office", "Educational and research",
+                     "Faculty papers", "Healthcare", "Historic preservation", "Industrial", "Interior Design",
+                     "Landscape Architecture", "Office records", "Personal papers", "Portrait",
+                     "Professional papers", "Project records", "Public buildings (governmental buildings)",
+                     "Reference files", "Religious building spaces", "Renovations", "Residential",
+                     "Residential-Housing development", "Residential-Multi-family", "Residential-Single-family",
+                     "Single-family", "Single-story", "Student work", "Travel", "Two-story", "Urban Design"]
     keyword_names.each do |name|
       ControlledVocab.find_or_create_by(name: name) do |c_v|
         c_v.field = 'keyword_sim'


### PR DESCRIPTION
Add line number to error messages

Create item with metadata from csv in background job

Pick files under Item identifier and attach as remote files

Update controlled vocabs

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1486) (:star:)

# What does this Pull Request do? (:star:)
Batch import metadata and files into Items from mounted server

# What's the changes? (:star:)

* Added CSV parser
* Added metadata file validations
* Added background importer to create item objects along with the files 
* The files in the Access folder are picked up based on the file directory path with which the folder name above the Access folder is the corresponding Item identifier

# How should this be tested?

A description of what steps someone could take to:
* Go to the spec_scan shared folder and find a testing collection (Rudoff is a good candidate)
* Create a parent collection (e.g., Rudoff) otherwise an error will occur.
* Copy a CSV file and pick some files in the folder which corresponds to the CSV file 
* The CSV file should be in tmp/imports
* The files should be in corresponding folder: (e.g., tmp/imports/Ms1990_025_Rudoff/Ms1990_025_Box1/Ms1990_025_Folder1/Ms1990_025_Per_Eph_B001_F001_001/Access)
* Go to dashboard -> Works --> Batch Import Items, see example inputs 
<img width="800" alt="screen shot 2018-09-04 at 3 14 38 pm" src="https://user-images.githubusercontent.com/8228221/45052641-7cf5ea80-b055-11e8-9c23-f56607285fa4.png">

and then click on Import button

# Additional Notes:

* LIBTD-1486 branch to be used for testing this PR?

# Interested parties
Tag (@shabububu)
(:star:) Required fields
